### PR TITLE
Fix shorten_parameters method

### DIFF
--- a/lib/firebase_dynamic_link/client.rb
+++ b/lib/firebase_dynamic_link/client.rb
@@ -131,8 +131,6 @@ module FirebaseDynamicLink
       dynamic_link_domain = options.delete(:dynamic_link_domain)
       dynamic_link_domain ||= config.dynamic_link_domain || raise(FirebaseDynamicLink::InvalidConfig, "Dynamic link domain is empty")
 
-      dynamic_link_domain = dynamic_link_domain
-
       params = CaseTransform2.camel_lower(dynamic_link_info: params.merge(domainUriPrefix: dynamic_link_domain),
                                          suffix: {
                                            option: suffix_option || config.suffix_option

--- a/lib/firebase_dynamic_link/client.rb
+++ b/lib/firebase_dynamic_link/client.rb
@@ -131,9 +131,9 @@ module FirebaseDynamicLink
       dynamic_link_domain = options.delete(:dynamic_link_domain)
       dynamic_link_domain ||= config.dynamic_link_domain || raise(FirebaseDynamicLink::InvalidConfig, "Dynamic link domain is empty")
 
-      dynamic_link_domain = URI.parse(dynamic_link_domain).host
+      dynamic_link_domain = dynamic_link_domain
 
-      params = CaseTransform2.camel_lower(dynamic_link_info: params.merge(dynamicLinkDomain: dynamic_link_domain),
+      params = CaseTransform2.camel_lower(dynamic_link_info: params.merge(domainUriPrefix: dynamic_link_domain),
                                          suffix: {
                                            option: suffix_option || config.suffix_option
                                          })


### PR DESCRIPTION
I don't see anywhere in the doc `dynamicLinkDomain` parameters.

Cf. https://firebase.google.com/docs/dynamic-links/rest#create_a_short_link_from_parameters

This is a fix fixing this and now it's supporting suffixed url like `mydomain.page.link/links` and working for me.

Regards