### PR TITLE
Support Dry Configurable >= 0.13

### DIFF
--- a/lib/firebase_dynamic_link.rb
+++ b/lib/firebase_dynamic_link.rb
@@ -12,7 +12,7 @@ module FirebaseDynamicLink
   extend Dry::Configurable
 
   USE_FARADAY_2 = Faraday::VERSION.to_i == 2
-  USE_DRY_CONFIGURABLE_0_13 = Dry::Configurable::VERSION.to_f == 0.13
+  USE_DRY_CONFIGURABLE_0_13 = Dry::Configurable::VERSION.to_f >= 0.13
 
   # called when invalid configuration given
   class InvalidConfig < StandardError; end


### PR DESCRIPTION
So we avoid warnings

```
/app/vendor/bundle/ruby/3.1.0/gems/firebase_dynamic_link-1.1.0/lib/firebase_dynamic_link.rb:11:in `<top (required)>' [dry-configurable] default value as positional argument to settings is deprecated and will be removed in the next major version
Provide a `default:` keyword argument instead
```