### PR TITLE
Fix dry-configurable warning

### DIFF
--- a/lib/firebase_dynamic_link.rb
+++ b/lib/firebase_dynamic_link.rb
@@ -12,7 +12,7 @@ module FirebaseDynamicLink
   extend Dry::Configurable
 
   USE_FARADAY_2 = Faraday::VERSION.to_i == 2
-  USE_DRY_CONFIGURABLE_0_13 = Dry::Configurable::VERSION.to_f == 0.13
+  USE_DRY_CONFIGURABLE_0_13 = Dry::Configurable::VERSION.to_f >= 0.13
 
   # called when invalid configuration given
   class InvalidConfig < StandardError; end

--- a/lib/firebase_dynamic_link/version.rb
+++ b/lib/firebase_dynamic_link/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FirebaseDynamicLink
-  VERSION = '1.1.1'
+  VERSION = '1.1.1'.freeze
 end

--- a/lib/firebase_dynamic_link/version.rb
+++ b/lib/firebase_dynamic_link/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FirebaseDynamicLink
-  VERSION = '1.1.0'
+  VERSION = '1.1.1'
 end


### PR DESCRIPTION
- Consider dry-configurable version 0.13 _and above_ to avoid warning (see screenshot below)
- Bump version from 1.1.0 to 1.1.1

---
#### Warning shown with dry-configurable at version 0.15
![Screen Shot 2022-05-18 at 12 47 31 PM](https://user-images.githubusercontent.com/1298460/169034086-37c6db21-6f1a-4949-9f8b-e2ad96b8d614.png)

