### PR TITLE
chore: bump version, drop Ruby 2.6 support because EOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ Firebase Dynamic Link is a tool to create a deep link of your webpage. It can be
   - [Shorten parameters](#shorten-parameters)
   - [More than one firebase project](#more-than-one-firebase-project)
 - [CHANGELOG](#changelog)
-  - [V1.0.5](#v105)
-  - [V1.0.3](#v103)
 - [Development](#development)
 - [Contributing](#contributing)
 - [License](#license)

--- a/firebase_dynamic_link.gemspec
+++ b/firebase_dynamic_link.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/saiqulhaq/firebase_dynamic_link'
   spec.license       = 'MIT'
   spec.metadata['yard.run'] = 'yri'
+  spec.required_ruby_version = '>= 2.7.0'
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})

--- a/lib/firebase_dynamic_link/version.rb
+++ b/lib/firebase_dynamic_link/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FirebaseDynamicLink
-  VERSION = '2.0.0'
+  VERSION = '2.0.1'
 end

--- a/lib/firebase_dynamic_link/version.rb
+++ b/lib/firebase_dynamic_link/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FirebaseDynamicLink
-  VERSION = '1.1.0'
+  VERSION = '2.0.0'
 end

--- a/spec/firebase_dynamic_link_spec.rb
+++ b/spec/firebase_dynamic_link_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe FirebaseDynamicLink do
   before(:all) { described_class.reset_config }
 
   it 'has a version number' do
-    expect(FirebaseDynamicLink::VERSION).to eq('1.1.0')
+    expect(FirebaseDynamicLink::VERSION).to eq('2.0.0')
   end
 
   describe '.config' do

--- a/spec/firebase_dynamic_link_spec.rb
+++ b/spec/firebase_dynamic_link_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe FirebaseDynamicLink do
   before(:all) { described_class.reset_config }
 
   it 'has a version number' do
-    expect(FirebaseDynamicLink::VERSION).to eq('2.0.0')
+    expect(FirebaseDynamicLink::VERSION).to eq('2.0.1')
   end
 
   describe '.config' do


### PR DESCRIPTION
Drop support of:

1. Ruby v2.6
2. Old faraday <= v0.17
3. Old dry-configurable <= v0.9

Add support of:

1. Ruby v3.1
2. Dry-configurable v0.15
3. Faraday v2.3